### PR TITLE
Make KE thresholds for killing tracks configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 G4History.macro
 *.dk2nu.root
+*~

--- a/README.md
+++ b/README.md
@@ -1,0 +1,191 @@
+# Booster Neutrino Beam Simulation project
+
+This repository has been migrated from [Redmine](https://cdcvs.fnal.gov/redmine/projects/booster-neutrino-beamline/wiki/Git_Help).
+
+The current version is based on the MiniBooNE BooNEG4Beam.
+The original code can be found under "BooNE-BackTrack subproject":https://cdcvs.fnal.gov/redmine/projects/boone-backtrack/repository.
+
+The old code has been cleaned up, partly rewritten and rearranged to get it up to date and working against current versions of geant4.
+[Wiki_old](https://cdcvs.fnal.gov/redmine/projects/booster-neutrino-beamline/wiki/Wiki_old) covers some of the validation work by Paul Lebrun while transitioning.
+There were two repositories within the main Redmine project page, one used during the upgrade (booster-neutrino-beamline) and one with the final working version where code has been further restructured (booster-neutrino-beamline-g4bnb).
+The latter one has been migrated here to GitHub.
+
+The current working version of G4BNB v1.0 uses GEANT4.10.4, and can be cloned using the geant4_10_4 branch.
+A branch is also available that uses GEANT4.10.6, named g4bnb-geant4-10-6-build. The master branch can be built with GEANT4.10.1.
+Relevant set up scripts for each version are provided in the branch.
+
+## Downloading the G4BNB code
+
+The G4BNB software is maintained in this git repository.
+
+Authenticated clone (i.e., allows to modify the software and upload your modification on this site, via git push):
+
+```
+git clone https://github.com/SBNSoftware/G4BNB.git
+``` 
+
+To check out a preexisting branch from the repository (recommended to run the current working version or development versions), you can clone the repository as above, then do:
+```
+$ cd <repository directory name>
+$ git checkout origin/<branch name>
+$ git checkout -b <branch name>
+```
+This will create a local branch from the remote branch. The current working version of G4BNB is on the branch "geant4_10_4". 
+
+To check out a fixed release of G4BNB (which is recommended for large production runs) into a directory with the name of the tag, you can do:
+```
+$ git clone https://github.com/SBNSoftware/G4BNB.git <tag_name>
+$ cd <tag_name>
+$ git checkout <tag_name>
+```
+You can see a list of available tags by doing:
+```
+git tag
+```
+
+## Building G4BNB at Fermilab
+
+If building G4BNB on the Fermilab gpvms, an SL7 container will be needed. An apptainer can be activated by:
+```
+sh /exp/$(id -ng)/data/users/vito/podman/start_SL7dev.sh
+```
+This apptainer does not support jobsub.
+
+To setup the correct software dependancies, use the setup scripts provided in the `/scripts` directory.
+The setup scripts have the relevant GEANT4 version number in their name.
+Assuming you are using the current `v1.0` working version (branch `geant4_10_4`), setup by running:
+```
+source scripts/setup_g4104.sh
+```
+
+cd into build directory and run:
+```
+cmake ../
+make -j4
+make install
+```
+
+## Submit grid jobs
+
+It is recommended to submit jobs directly from the AL9 gpvm node without using an SL7 container.
+The `submitBeam.py` script sets up a singularity image of SL7 on the grid.
+To submit grid jobs use submitBeam.py script:
+
+```
+usage: submitBeam.py [-h] -n [1-10000] -b BIN -i INPUT -g GEOMETRY
+                     [-c HORNCURRENT] [-j JOBID] [-o OUTPUTPATH] [-p POT]
+                     [-r RANDOMSEED] [-d]
+
+Submit beam MC jobs.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n [1-10000]          Number of jobs to submit.
+  -b BIN, --bin BIN     Path to beam g4 executable. Bin dir where exe files
+                        are installed.
+  -i INPUT, --input INPUT
+                        Job options input file.
+  -g GEOMETRY, --geometry GEOMETRY
+                        GDML geometry file
+  -c HORNCURRENT, --horn-current HORNCURRENT
+                        Horn current in A. If specified overwrites
+                        /boone/field/horncurrent and
+                        /boone/field/skin/SkinDepthHornCurrent commands.
+  -j JOBID, --jobidoffset JOBID
+                        Id for running job. If submitting multiple jobs each
+                        one is offset by its process number (0..n)
+  -o OUTPUTPATH, --output-path OUTPUTPATH
+                        Path where to copy final output.
+                        (default=/pnfs/uboone/scratch/users/${USER}/beammc)
+  -p POT, --pot POT     Protons on target per job. If specified overwrites
+                        /run/beamOn command.
+  -r RANDOMSEED, --random-seed RANDOMSEED
+                        Random seed RS. Each process gets seed=$((PROCESS+RS))
+  -d, --debug           Will not delete submission files in the end. Useful
+                        for debugging and will only print the submission
+                        command on screen.
+```
+
+Example to submit 100 jobs with 50000 POT each using `production.in` input file as template (note that `submitBeam.py` overrides POT, horn current and geometry):
+```
+bin/v4_10_4_p02d/submitBeam.py -n 100 -b bin/v4_10_4_p02d/ -i input/production.in -g geometry/BooNE_50m.gdml  -p 50000
+```
+
+Different production scripts have been provided to enable decay at rest (DAR) for only muons and both muons and pions. These are called `production_muDAR.in` and `production_muDAR_piDAR.in` respectively.
+The production ntuple can be saved in the output files by uncommenting the line that reads
+```
+#/boone/output/saveProductionNtuple true
+```
+
+## Analyzing beam MC
+The output of the beam MC are [dk2nu beam ntuples](https://cdcvs.fnal.gov/redmine/projects/dk2nu/wiki/Wiki).
+Code to produce standard set of histograms is in `scripts/beamHist.cc` and gets compiled with beam MC.
+```
+Options:
+  --help                     Print help message
+  --input arg                Path pattern for input files. Put it in quotes or 
+                             escape *.
+  --output arg (=hist.root)  Output file name.
+  --pot arg                  POT used for normalization (overides counting 
+                             using info in meta tree and speeds up process). 
+                             Total POT should be given (number of files X POT 
+                             per file).
+  --nredecays arg (=1)       Number of redecays.
+  --detector-radius arg (=0) Detector radius (in cm).
+  --detector-position arg    Detector position (in cm).
+  --thread arg (=1)          Number of threads to run. (max set to 8)
+```
+
+Example to produce histograms from previously generated jobs:
+```
+./bin/v4_10_4_p02d/beamHist --input /pnfs/uboone/scratch/users/${USER}/beammc/production_BooNE_50m_I174000A/\*/\*dk2nu.root --detector-radius 200 --detector-position 73.78 0 11000 --thread 4 --output hist_sbnd.root
+```
+
+This might take a while if analyzing many jobs. submitBeam.py actually runs the beamHist command on the grid and produces histogram files for sbnd, uboone, miniboone, icarus locations:
+
+ |                    |        x/cm   |         y/cm   |            z/cm | r/cm |
+ | ---|---|---|---|---|
+ |  sbnd             |         73.78          |         0            |    11000   | 200   |
+ | uboone          |         0          |         0            |    47000 |  200   |
+ | miniboone     |         0          | 189.614          |    54134  |  610   |
+ | icarus             |        0           |        0             |   60000  |  200   |
+
+
+One can merge those histograms to save some time. For this use `mergeHist.py` script:
+```
+usage: mergeHist.py [-h] -i INPUT [-o OUTPUT] [-l LOCATION]
+
+Merge beam MC histograms.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INPUT, --input INPUT
+                        Path to top directory containing histograms to merge.
+  -o OUTPUT, --output OUTPUT
+                        Output root file.
+  -l LOCATION, --location LOCATION
+                        Used to pick the correct hist file. (grid jobs create
+                        sbnd, uboone, icarus, miniboone by default.)
+```
+
+For example to merge histograms from previously ran jobs:
+```
+bin/v4_10_4_p02d/mergeHist.py -i /pnfs/uboone/scratch/users/${USER}/beammc/production_BooNE_50m_I174000A/  -l miniboone
+```
+This creates hist_miniboone.root. Merge script scales histograms dividing out the number of files so normalization is always the same, assuming the files each have the same POT in them.
+
+## Making plots
+
+Histograms can be plotted in the usual way using root. 
+`compare.py` script is provided that can overlay multiple histograms and produce standard set of plots.
+```
+usage: compare.py [-h] -d DATA -c COMPARE [COMPARE ...] [-o OUTPUT]
+compare.py: error: argument -d/--data is required
+```
+
+Example to compare to the original MiniBooNE flux histogram:
+```
+bin/v4_10_4_p02d/compare.py -d validation/april07_baseline_rgen610.6_fixrnd_20171212.root -c hist_miniboone.root -o miniboone_plot.pdf
+```
+
+Multiple histogram files can be listed after -c option and those will all be compared to file under `-d` option.

--- a/include/NuBeamStackingAction.hh
+++ b/include/NuBeamStackingAction.hh
@@ -6,9 +6,11 @@
 #include "globals.hh"
 #include "G4ThreeVector.hh"
 #include "G4UserStackingAction.hh"
+#include "NuBeamStackingActionMessenger.hh"
 
 class G4Track;
 class G4RunManager;
+class NuBeamStackingActionMessenger;
 
 class NuBeamStackingAction : public G4UserStackingAction
 {
@@ -26,9 +28,14 @@ public:
   void KillThresholdParticles(G4ClassificationOfNewTrack& classification, 
 			       const G4Track * aTrack);
   
+  G4double GetLowKEThreshold() const { return fLowKEThreshold; };
+  void SetLowKEThreshold(G4double val){ fLowKEThreshold = val; };
+  
 private:
   G4RunManager * fRunManager; 
-   
+  
+  NuBeamStackingActionMessenger* fMessenger;
+  G4double fLowKEThreshold;
 };
 
 #endif

--- a/include/NuBeamStackingActionMessenger.hh
+++ b/include/NuBeamStackingActionMessenger.hh
@@ -1,0 +1,27 @@
+#ifndef NuBeamStackingActionMessenger_h
+#define NuBeamStackingActionMessenger_h 1
+
+#include "globals.hh"
+#include "G4UImessenger.hh"
+
+class NuBeamStackingAction;
+class G4UIdirectory;
+class G4UIcommand;
+class G4UIcmdWithADoubleAndUnit;
+
+class NuBeamStackingActionMessenger: public G4UImessenger
+{
+public:
+   NuBeamStackingActionMessenger(NuBeamStackingAction*);
+  ~NuBeamStackingActionMessenger();
+
+  void SetNewValue(G4UIcommand*, G4String);
+
+private:
+  NuBeamStackingAction* fStacker;
+  
+  G4UIdirectory*             fDirectory;
+  G4UIcmdWithADoubleAndUnit* fLowKEThresholdCmd;
+};
+
+#endif // #ifndef NuBeamStackingActionMessenger_h

--- a/input/production.in
+++ b/input/production.in
@@ -219,7 +219,7 @@
 # 
 /boone/output/filename nubeam.dk2nu.root
 
-#/boone/output/saveProductionNtuple true
+#/boone/output/saveProductionNtuple true # saves everything coming out of primary interaction
 # define aux ntuples
 # particles exiting exitVolName and entering enterVolName will be recorded in treeName tree
 # /boone/output/boundaryNtuple treeName exitVolName enterVolName
@@ -233,6 +233,12 @@
 /boone/output/pionMomentumThr 1. MeV
 /boone/output/muonMomentumThr 1. MeV
 /boone/output/kaonMomentumThr -1. MeV
+
+#
+# set threshold for killing tracks
+#
+/boone/stacking/lowKEThreshold 50. MeV
+
 #
 # set verbosities
 #
@@ -241,14 +247,14 @@
 /process/verbose 0
 /tracking/verbose 0
 /event/verbose 0
-/run/verbose 1
+/run/verbose 0
 /control/saveHistory 
-/event/printModulo 10
+/event/printModulo 100
 
 # Start simulation
 # ----------------
 # Specify number of protons on target
-/run/beamOn 1000
+/run/beamOn 1
 
 # Termination
 # -----------

--- a/scripts/setup_g4106.sh
+++ b/scripts/setup_g4106.sh
@@ -1,0 +1,14 @@
+source /cvmfs/fermilab.opensciencegrid.org/products/genie/bootstrap_genie_ups.sh
+source /cvmfs/larsoft.opensciencegrid.org/products/setups
+source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setup
+
+setup gcc v4_9_3
+setup geant4 v4_10_6_p01g -q e26:prof
+setup dk2nudata v01_10_01f -q e26:prof
+setup cmake v3_9_5
+setup jobsub_client
+setup ifdhc
+# For beamHist
+setup boost v1_82_0 -q e26:prof
+#For debug
+setup gdb v10_1

--- a/src/BooNEHadronElasticPhysics.cc
+++ b/src/BooNEHadronElasticPhysics.cc
@@ -8,6 +8,8 @@
 #include "G4MesonConstructor.hh"
 #include "G4BaryonConstructor.hh"
 
+#include "G4Version.hh"
+#define G4VERSION_MAJOR_MINOR (G4VERSION_NUMBER / 10) // last digit is patch.
 
 BooNEHadronElasticPhysics::BooNEHadronElasticPhysics(G4int)
   :  G4VPhysicsConstructor("BooNEHadronElasticPhysics")
@@ -71,6 +73,9 @@ void BooNEHadronElasticPhysics::ConstructProcess()
     }
   }
   fBooNEHadronElasticProcess.RegisterMe(&fBooNEHadronElasticModel);
+#if G4VERSION_MAJOR_MINOR >= 106 // code for v10.6++
+  fBooNEHadronElasticProcess.AddDataSet(new G4HadronElasticDataSet());
+#endif // check G4VERSION
   fBooNEHadronElasticProcess.AddDataSet(&fBooNEHadronElasticData);
 
 }

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -17,6 +17,9 @@
 #include "G4PreCompoundModel.hh"
 #include "G4BGGNucleonInelasticXS.hh"
 
+#include "G4Version.hh"
+#define G4VERSION_MAJOR_MINOR (G4VERSION_NUMBER / 10) // last digit is patch.
+
 BooNEHadronInelasticProcess::
 BooNEHadronInelasticProcess(const G4ParticleDefinition& aParticleType)
   :  G4HadronicProcess("BooNEHadronInelastic")
@@ -165,9 +168,15 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
   G4Element* anElement = 0;
   try
   {
+#if G4VERSION_MAJOR_MINOR <= 104 // code for v10.4
     anElement = GetCrossSectionDataStore()->SampleZandA(aParticle,
-							 aMaterial,
-							 *GetTargetNucleusPointer());
+							aMaterial,
+							*GetTargetNucleusPointer());
+#elif G4VERSION_MAJOR_MINOR >= 106 // code for v10.6++
+    anElement = (G4Element*) GetCrossSectionDataStore()->SampleZandA(aParticle,
+								     aMaterial,
+								     *GetTargetNucleusPointer());
+#endif // check G4VERSION
   }
   catch(G4HadronicException & aR)
   {

--- a/src/NuBeamStackingAction.cc
+++ b/src/NuBeamStackingAction.cc
@@ -10,16 +10,22 @@
 #include "G4VPhysicalVolume.hh"
 #include "G4TrajectoryContainer.hh"
 #include "G4ios.hh"
+#include "G4UImanager.hh"
 #include "NuBeamTrackInformation.hh"
 #include "NuBeamTrajectory.hh"
 #include "NuBeamRunManager.hh"
 
-NuBeamStackingAction::NuBeamStackingAction()
+NuBeamStackingAction::NuBeamStackingAction(): fMessenger(0)
 { 
+  fMessenger = new NuBeamStackingActionMessenger(this);
+  G4UImanager* UI = G4UImanager::GetUIpointer();
+  UI->ApplyCommand("/boone/stacking/lowKEThreshold");
 }
 
 NuBeamStackingAction::~NuBeamStackingAction()
 {
+  delete fMessenger;
+  fMessenger = 0;
 }
 
 G4ClassificationOfNewTrack NuBeamStackingAction::ClassifyNewTrack(const G4Track * aTrack)
@@ -71,8 +77,8 @@ void NuBeamStackingAction::KillThresholdParticles(G4ClassificationOfNewTrack& cl
       (particleType!=G4AntiNeutrinoTau::AntiNeutrinoTau())) {
     G4double energy = aTrack->GetKineticEnergy();
     
-    if ((energy < 0.05*CLHEP::GeV ) && (classification != fKill))
-      {classification = fKill;} 
+    if ((energy < fLowKEThreshold * CLHEP::MeV/CLHEP::GeV ) && (classification != fKill))
+      {classification = fKill;}
   }  
 }
 

--- a/src/NuBeamStackingActionMessenger.cc
+++ b/src/NuBeamStackingActionMessenger.cc
@@ -1,0 +1,38 @@
+#include "NuBeamStackingActionMessenger.hh"
+#include "NuBeamStackingAction.hh"
+
+#include "G4UIcommand.hh"
+#include "G4Tokenizer.hh"
+#include "G4UIcmdWithADoubleAndUnit.hh"
+#include "G4ios.hh"
+#include "globals.hh"
+#include "G4UIdirectory.hh"
+
+#include <sstream>
+using namespace std;
+
+NuBeamStackingActionMessenger::NuBeamStackingActionMessenger(NuBeamStackingAction* S) :
+  fStacker(S)
+{
+  fDirectory = new G4UIdirectory("/boone/stacking/");
+  fDirectory->SetGuidance( "BooNE stacking action control commands." );
+
+  fLowKEThresholdCmd = new G4UIcmdWithADoubleAndUnit("/boone/stacking/lowKEThreshold", this);
+  fLowKEThresholdCmd->SetGuidance("Threshold of kinetic energy below which tracks are killed");
+  fLowKEThresholdCmd->SetGuidance("Available options: any positive floating-point number, with a valid unit (e.g. MeV, GeV, etc.)");
+  fLowKEThresholdCmd->SetParameterName("lowKEThreshold", true, false);
+  fLowKEThresholdCmd->SetDefaultUnit("MeV");
+  fLowKEThresholdCmd->SetDefaultValue(50.);
+}
+
+NuBeamStackingActionMessenger::~NuBeamStackingActionMessenger()
+{
+  delete fLowKEThresholdCmd;
+  delete fDirectory;
+}
+
+void NuBeamStackingActionMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
+{
+  if(command == fLowKEThresholdCmd)
+    fStacker->SetLowKEThreshold(fLowKEThresholdCmd->GetNewDoubleValue(newValue));
+}


### PR DESCRIPTION
The kinetic energy threshold for killing tracks in NuBeamStackingAction was hardcoded to 50 MeV. This PR makes this configurable, using `/boone/stacking/lowKEThreshold` (default 50 MeV). 

Also added checks to NuBeamElasticPhysics.cc and NuBeamHadronInelasticProcess.cc to read the G4 version number. This is to keep a single copy of these files for G4.10.4 and G4.10.6.