### PR TITLE
Revert validation-breaking change

### DIFF
--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -311,13 +311,6 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
     tInfo->SetCreatorModelName(GetHadronicInteraction()->GetModelName()); 
   }
 
-  // Revert the old track info to get it stored properly in the last step of ancestry tree
-  // Same as in BooNEHadronElasticProcess.cc
-  theTotalResult->ProposeMomentumDirection(aTrack.GetMomentumDirection());
-  theTotalResult->ProposeEnergy(aTrack.GetKineticEnergy());
-  theTotalResult->ProposePolarization(aTrack.GetPolarization());
-  theTotalResult->ProposeVelocity(aTrack.GetVelocity());
-
   return theTotalResult;
 }
 


### PR DESCRIPTION
This reverts commit [be5f759b](https://github.com/SBNSoftware/G4BNB/commit/be5f759b5abeab9b294c700b59dc95c115b1ff10) which introduced an inadvertent change in the geant 4.10.4 prediction (see screenshot). Reverting this commit restores the validation histogram.

<img width="336" height="417" alt="image" src="https://github.com/user-attachments/assets/a0999cd3-f85e-498f-ab49-bdbf4535efca" />

