### PR TITLE
Fixes stopping momentum bug for G4.10.6

### DIFF
--- a/include/NuBeamOutput.hh
+++ b/include/NuBeamOutput.hh
@@ -12,6 +12,7 @@
 #include "G4LogicalVolumeStore.hh"
 
 #include "NuBeamTrajectory.hh"
+#include "NuBeamTrajectoryContainer.hh"
 #include "NuBeamLocalField.hh"
 #include "NuBeamSkinDepthField.hh"
 #include "dk2nu/tree/dk2nu.h"

--- a/include/NuBeamTrajectory.hh
+++ b/include/NuBeamTrajectory.hh
@@ -17,8 +17,7 @@
 
 class G4Polyline;                   // Forward declaration.
 
-//typedef std::vector<G4VTrajectoryPoint*>  NuBeamTrajectoryPointContainer;
-typedef std::vector<std::shared_ptr<G4TrajectoryPoint>>  NuBeamTrajectoryPointContainer;
+typedef std::vector<G4VTrajectoryPoint*>  NuBeamTrajectoryPointContainer;
 
 class NuBeamTrajectory : public G4VTrajectory
 {
@@ -29,8 +28,8 @@ public:
   NuBeamTrajectory(NuBeamTrajectory &);
   virtual ~NuBeamTrajectory();
 
-  //inline void* operator new(size_t);
-  //inline void  operator delete(void*);
+  inline void* operator new(size_t);
+  inline void  operator delete(void*);
   inline int operator == (const NuBeamTrajectory& right) const
   {return (this==&right);} 
   
@@ -219,13 +218,12 @@ public:
 
   virtual int GetPointEntries() const { return fPositionRecord.size(); }
   virtual G4VTrajectoryPoint* GetPoint(G4int i) const 
-  { return (fPositionRecord[i]).get(); }
+  { return fPositionRecord[i]; }
 };
 
 
 extern G4Allocator<NuBeamTrajectory> aTrajectoryAlloc;
 
-/*
 inline void* NuBeamTrajectory::operator new(size_t)
 {
   void* aTrajectory;
@@ -237,7 +235,6 @@ inline void NuBeamTrajectory::operator delete(void* aTrajectory)
 {
   aTrajectoryAlloc.FreeSingle((NuBeamTrajectory*)aTrajectory);
 }
-*/
 
 #endif
 

--- a/include/NuBeamTrajectory.hh
+++ b/include/NuBeamTrajectory.hh
@@ -19,6 +19,21 @@ class G4Polyline;                   // Forward declaration.
 
 typedef std::vector<G4VTrajectoryPoint*>  NuBeamTrajectoryPointContainer;
 
+namespace trajectory {
+  struct trajPoint_t {
+    G4String      fCreatorProcessName;
+    G4double      fEnergy;
+    G4ThreeVector fMomentum;
+    G4ThreeVector fPosition;
+    G4ThreeVector fPolarization;
+    G4double      fTime;
+    G4int         fStepNumber;
+    G4int         fMaterialNumber;
+    G4String      fMaterialName;
+    G4String      fVolumeName;
+  };
+}
+
 class NuBeamTrajectory : public G4VTrajectory
 {
 public:
@@ -147,23 +162,8 @@ public:
   inline void SetFinalStepNumber(const G4int aValue)
   {fFinalStepNumber = aValue;}
 
-
-  struct trajPoint_t {
-    G4String      fCreatorProcessName;
-    G4double      fEnergy;
-    G4ThreeVector fMomentum;
-    G4ThreeVector fPosition;
-    G4ThreeVector fPolarization;
-    G4double      fTime;
-    G4int         fStepNumber;
-    G4int         fMaterialNumber;
-    G4String      fMaterialName;
-    G4String      fVolumeName;
-  };
-
-
   void AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc);
-  std::vector<trajPoint_t> GetTrajectoryPoints(){return fTrajectoryPoints;};
+  std::vector<trajectory::trajPoint_t> GetTrajectoryPoints(){return fTrajectoryPoints;};
 
   // method to retrieve the parent trajectory for any trajectory
   NuBeamTrajectory* GetParentTrajectory();
@@ -181,7 +181,7 @@ private:
   
   NuBeamTrajectoryPointContainer fPositionRecord;
 
-  std::vector<trajPoint_t> fTrajectoryPoints;
+  std::vector<trajectory::trajPoint_t> fTrajectoryPoints;
 
   // static track information
   G4ParticleDefinition* fpParticleDefinition;

--- a/include/NuBeamTrajectory.hh
+++ b/include/NuBeamTrajectory.hh
@@ -17,7 +17,8 @@
 
 class G4Polyline;                   // Forward declaration.
 
-typedef std::vector<G4VTrajectoryPoint*>  NuBeamTrajectoryPointContainer;
+//typedef std::vector<G4VTrajectoryPoint*>  NuBeamTrajectoryPointContainer;
+typedef std::vector<std::shared_ptr<G4TrajectoryPoint>>  NuBeamTrajectoryPointContainer;
 
 class NuBeamTrajectory : public G4VTrajectory
 {
@@ -28,8 +29,8 @@ public:
   NuBeamTrajectory(NuBeamTrajectory &);
   virtual ~NuBeamTrajectory();
 
-  inline void* operator new(size_t);
-  inline void  operator delete(void*);
+  //inline void* operator new(size_t);
+  //inline void  operator delete(void*);
   inline int operator == (const NuBeamTrajectory& right) const
   {return (this==&right);} 
   
@@ -218,12 +219,13 @@ public:
 
   virtual int GetPointEntries() const { return fPositionRecord.size(); }
   virtual G4VTrajectoryPoint* GetPoint(G4int i) const 
-  { return fPositionRecord[i]; }
+  { return (fPositionRecord[i]).get(); }
 };
 
 
 extern G4Allocator<NuBeamTrajectory> aTrajectoryAlloc;
 
+/*
 inline void* NuBeamTrajectory::operator new(size_t)
 {
   void* aTrajectory;
@@ -235,6 +237,7 @@ inline void NuBeamTrajectory::operator delete(void* aTrajectory)
 {
   aTrajectoryAlloc.FreeSingle((NuBeamTrajectory*)aTrajectory);
 }
+*/
 
 #endif
 

--- a/include/NuBeamTrajectory.hh
+++ b/include/NuBeamTrajectory.hh
@@ -179,7 +179,7 @@ public:
   
 private:
   
-  NuBeamTrajectoryPointContainer* fPositionRecord;
+  NuBeamTrajectoryPointContainer fPositionRecord;
 
   std::vector<trajPoint_t> fTrajectoryPoints;
 
@@ -216,9 +216,9 @@ private:
 
 public:
 
-  virtual int GetPointEntries() const { return fPositionRecord->size(); }
+  virtual int GetPointEntries() const { return fPositionRecord.size(); }
   virtual G4VTrajectoryPoint* GetPoint(G4int i) const 
-  { return (*fPositionRecord)[i]; }
+  { return fPositionRecord[i]; }
 };
 
 

--- a/include/NuBeamTrajectoryContainer.hh
+++ b/include/NuBeamTrajectoryContainer.hh
@@ -17,6 +17,7 @@ public:
   
   NuBeamTrajectory GetTrajectory(int id);
   inline size_t GetNTrajectories() { return fTrajectories.size(); }
+  inline bool ContainsTrajectory(int id) { return fTrajectories.count(id); }
 
   // Add a trajectory
   void AddTrajectory(NuBeamTrajectory traj);

--- a/include/NuBeamTrajectoryContainer.hh
+++ b/include/NuBeamTrajectoryContainer.hh
@@ -19,7 +19,6 @@ public:
   inline size_t GetNTrajectories() { return fTrajectories.size(); }
 
   // Add a trajectory
-  // Don't add by reference, as this shares a pointer to the PositionRecord of the NBTrajectory...
   void AddTrajectory(NuBeamTrajectory traj);
 
   // Clear in between events

--- a/include/NuBeamTrajectoryContainer.hh
+++ b/include/NuBeamTrajectoryContainer.hh
@@ -1,0 +1,37 @@
+#ifndef BooNETrajectoryContainer_h
+#define BooNETrajectoryContainer_h 1
+
+#include "NuBeamTrajectory.hh"
+#include <vector>
+#include <unordered_map> // make a hashmap of NuBeamTrajectories
+
+// This class is a singleton whose only goal is to store the vector of NuBeamTrajectory objects
+// later used in NuBeamOutput
+
+class NuBeamTrajectoryContainer {
+public:
+
+  static NuBeamTrajectoryContainer & Instance();
+  NuBeamTrajectoryContainer() = default;
+  ~NuBeamTrajectoryContainer();
+  
+  NuBeamTrajectory GetTrajectory(int id);
+  inline size_t GetNTrajectories() { return fTrajectories.size(); }
+
+  // Add a trajectory
+  // Don't add by reference, as this shares a pointer to the PositionRecord of the NBTrajectory...
+  void AddTrajectory(NuBeamTrajectory traj);
+
+  // Clear in between events
+  inline void Clear() { fTrajectories.clear(); }
+
+private:
+  
+  // Singletons don't like the Rule of Three. So delete the copy and move operations
+  NuBeamTrajectoryContainer(const NuBeamTrajectoryContainer&) = delete;
+  NuBeamTrajectoryContainer & operator=(const NuBeamTrajectoryContainer &) = delete;
+
+  std::unordered_map<int, NuBeamTrajectory> fTrajectories;
+};
+
+#endif // # ifndef BooNETrajectoryContainer_h

--- a/include/NuBeamTrajectoryContainer.hh
+++ b/include/NuBeamTrajectoryContainer.hh
@@ -15,12 +15,16 @@ public:
   NuBeamTrajectoryContainer() = default;
   ~NuBeamTrajectoryContainer();
   
-  NuBeamTrajectory GetTrajectory(int id);
+  NuBeamTrajectory & GetTrajectory(int id);
   inline size_t GetNTrajectories() { return fTrajectories.size(); }
   inline bool ContainsTrajectory(int id) { return fTrajectories.count(id); }
 
   // Add a trajectory
-  void AddTrajectory(NuBeamTrajectory traj);
+  void AddTrajectory(std::unique_ptr<NuBeamTrajectory> traj);
+
+  // Which event are we on?
+  inline G4int GetEvent() { return fEvtId; }
+  void SetEvent(G4int id) { fEvtId = id; }
 
   // Clear in between events
   inline void Clear() { fTrajectories.clear(); }
@@ -31,7 +35,9 @@ private:
   NuBeamTrajectoryContainer(const NuBeamTrajectoryContainer&) = delete;
   NuBeamTrajectoryContainer & operator=(const NuBeamTrajectoryContainer &) = delete;
 
-  std::unordered_map<int, NuBeamTrajectory> fTrajectories;
+  std::unordered_map<int, std::unique_ptr<NuBeamTrajectory>> fTrajectories;
+  // Keep track of the event to use
+  G4int fEvtId;
 };
 
 #endif // # ifndef BooNETrajectoryContainer_h

--- a/src/BooNEHadronElasticProcess.cc
+++ b/src/BooNEHadronElasticProcess.cc
@@ -1,6 +1,7 @@
 #include "BooNEHadronElasticProcess.hh"
 #include "NuBeamTrackInformation.hh"
 #include "NuBeamTrajectory.hh"
+#include "NuBeamTrajectoryContainer.hh"
 
 BooNEHadronElasticProcess::
 BooNEHadronElasticProcess(const G4String& processName)
@@ -31,8 +32,13 @@ G4VParticleChange* BooNEHadronElasticProcess::PostStepDoIt(const G4Track& aTrack
   }
   G4int nsec=theParticleChange->GetNumberOfSecondaries();
   theParticleChange->Clear();
-  secVec.push_back(newTrack); 
-  
+  secVec.push_back(newTrack);
+
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
+  tinst.AddTrajectory( traj );
+
+  /*
   //now revert the old track info to get it stored properly in the last step
   //of ancestry tree
   theParticleChange->ProposeMomentumDirection(aTrack.GetMomentumDirection());
@@ -51,6 +57,7 @@ G4VParticleChange* BooNEHadronElasticProcess::PostStepDoIt(const G4Track& aTrack
       tInfo->SetCreatorModelName(GetHadronicInteraction()->GetModelName());   
       theParticleChange->AddSecondary(secVec[i]);
   }
+  */
   
   return theParticleChange;
 }

--- a/src/BooNEHadronElasticProcess.cc
+++ b/src/BooNEHadronElasticProcess.cc
@@ -34,14 +34,6 @@ G4VParticleChange* BooNEHadronElasticProcess::PostStepDoIt(const G4Track& aTrack
   theParticleChange->Clear();
   secVec.push_back(newTrack);
 
-  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
-  int nprev = tinst.GetNTrajectories();
-  NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
-  tinst.AddTrajectory( traj );
-  int naft = tinst.GetNTrajectories();
-  if(nprev != naft)
-    G4cout << "Adding trajectory with ID " << aTrack.GetTrackID() << "..." << G4endl;
-
   /*
   //now revert the old track info to get it stored properly in the last step
   //of ancestry tree

--- a/src/BooNEHadronElasticProcess.cc
+++ b/src/BooNEHadronElasticProcess.cc
@@ -37,6 +37,7 @@ G4VParticleChange* BooNEHadronElasticProcess::PostStepDoIt(const G4Track& aTrack
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
   NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
   tinst.AddTrajectory( traj );
+  G4cout << "I have " << tinst.GetNTrajectories() << " trajectories now..." << G4endl;
 
   /*
   //now revert the old track info to get it stored properly in the last step

--- a/src/BooNEHadronElasticProcess.cc
+++ b/src/BooNEHadronElasticProcess.cc
@@ -35,9 +35,12 @@ G4VParticleChange* BooNEHadronElasticProcess::PostStepDoIt(const G4Track& aTrack
   secVec.push_back(newTrack);
 
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  int nprev = tinst.GetNTrajectories();
   NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
   tinst.AddTrajectory( traj );
-  G4cout << "I have " << tinst.GetNTrajectories() << " trajectories now..." << G4endl;
+  int naft = tinst.GetNTrajectories();
+  if(nprev != naft)
+    G4cout << "Adding trajectory with ID " << aTrack.GetTrackID() << "..." << G4endl;
 
   /*
   //now revert the old track info to get it stored properly in the last step

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -301,6 +301,11 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
     }
     tInfo->SetCreatorModelName(GetHadronicInteraction()->GetModelName()); 
   }
+  
+  // Add this trajectory to the container
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
+  tinst.AddTrajectory( traj );
 
   return theTotalResult;
 }

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -302,13 +302,6 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
     tInfo->SetCreatorModelName(GetHadronicInteraction()->GetModelName()); 
   }
 
-  // Revert the old track info to get it stored properly in the last step of ancestry tree
-  // Same as in BooNEHadronElasticProcess.cc
-  theTotalResult->ProposeMomentumDirection(aTrack.GetMomentumDirection());
-  theTotalResult->ProposeEnergy(aTrack.GetKineticEnergy());
-  theTotalResult->ProposePolarization(aTrack.GetPolarization());
-  theTotalResult->ProposeVelocity(aTrack.GetVelocity());
-
   return theTotalResult;
 }
 

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -306,6 +306,7 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
   NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
   tinst.AddTrajectory( traj );
+  G4cout << "I have " << tinst.GetNTrajectories() << " trajectories now..." << G4endl;
 
   return theTotalResult;
 }

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -301,15 +301,6 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
     }
     tInfo->SetCreatorModelName(GetHadronicInteraction()->GetModelName()); 
   }
-  
-  // Add this trajectory to the container
-  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
-  int nprev = tinst.GetNTrajectories();
-  NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
-  tinst.AddTrajectory( traj );
-  int naft = tinst.GetNTrajectories();
-  if(nprev != naft)
-    G4cout << "Adding trajectory with ID " << aTrack.GetTrackID() << "..." << G4endl;
 
   return theTotalResult;
 }

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -304,9 +304,12 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
   
   // Add this trajectory to the container
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  int nprev = tinst.GetNTrajectories();
   NuBeamTrajectory traj = NuBeamTrajectory(&aTrack);
   tinst.AddTrajectory( traj );
-  G4cout << "I have " << tinst.GetNTrajectories() << " trajectories now..." << G4endl;
+  int naft = tinst.GetNTrajectories();
+  if(nprev != naft)
+    G4cout << "Adding trajectory with ID " << aTrack.GetTrackID() << "..." << G4endl;
 
   return theTotalResult;
 }

--- a/src/NuBeamEventAction.cc
+++ b/src/NuBeamEventAction.cc
@@ -30,6 +30,9 @@ NuBeamEventAction::~NuBeamEventAction()
 
 void NuBeamEventAction::BeginOfEventAction(const G4Event* anEvent)
 {
+  // Clear any saved tracks...
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  if( tinst.GetNTrajectories() > 0 ) tinst.Clear();
   // Initiate record-keeping for this event.
   if (fRecords != NULL) fRecords->RecordBeginOfEvent(anEvent);
 

--- a/src/NuBeamEventAction.cc
+++ b/src/NuBeamEventAction.cc
@@ -35,7 +35,7 @@ void NuBeamEventAction::BeginOfEventAction(const G4Event* anEvent)
 
   G4int evtNb = anEvent->GetEventID();
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
-  if( evtNb != tinst.GetEvent() ) {
+  if( evtNb != tinst.GetEvent() ) { // Clear any saved tracks...
     tinst.SetEvent(evtNb);
   }
     

--- a/src/NuBeamEventAction.cc
+++ b/src/NuBeamEventAction.cc
@@ -30,13 +30,16 @@ NuBeamEventAction::~NuBeamEventAction()
 
 void NuBeamEventAction::BeginOfEventAction(const G4Event* anEvent)
 {
-  // Clear any saved tracks...
-  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
-  if( tinst.GetNTrajectories() > 0 ) tinst.Clear();
   // Initiate record-keeping for this event.
   if (fRecords != NULL) fRecords->RecordBeginOfEvent(anEvent);
 
   G4int evtNb = anEvent->GetEventID();
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  if( evtNb != tinst.GetEvent() ) { // Clear any saved tracks...
+    tinst.Clear();
+    tinst.SetEvent(evtNb);
+  }
+    
   //printing survey
   if (evtNb > 100)  fPrintModulo = 100;
   if (evtNb > 1000)  fPrintModulo = 1000;

--- a/src/NuBeamEventAction.cc
+++ b/src/NuBeamEventAction.cc
@@ -35,8 +35,7 @@ void NuBeamEventAction::BeginOfEventAction(const G4Event* anEvent)
 
   G4int evtNb = anEvent->GetEventID();
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
-  if( evtNb != tinst.GetEvent() ) { // Clear any saved tracks...
-    tinst.Clear();
+  if( evtNb != tinst.GetEvent() ) {
     tinst.SetEvent(evtNb);
   }
     
@@ -52,6 +51,8 @@ void NuBeamEventAction::BeginOfEventAction(const G4Event* anEvent)
 void NuBeamEventAction::EndOfEventAction(const G4Event* anEvent)
 {
   // Terminate record-keeping for this event.
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  tinst.Clear();
   if (fRecords != NULL)
     fRecords->RecordEndOfEvent(anEvent);	
 }

--- a/src/NuBeamOutput.cc
+++ b/src/NuBeamOutput.cc
@@ -356,11 +356,8 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
 
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
   std::vector<NuBeamTrajectory *> trajs;
-  G4cout << "Starting. We have a neutrino of ID = " << track->GetTrackID()
-	 << " and whose parent is " << track->GetParentID() << G4endl;
   G4int trackIDTmp = track->GetParentID();
   while (trackIDTmp > 0) {
-    G4cout << "We are looking at trackIDTmp = " << trackIDTmp << G4endl;
     // if we tracked this process, just look it up from our map
     NuBeamTrajectory *tmpTraj = GetTrajectory(trackIDTmp);    
     int par_id = tmpTraj->GetParentID();

--- a/src/NuBeamOutput.cc
+++ b/src/NuBeamOutput.cc
@@ -356,6 +356,8 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
 
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
   std::vector<NuBeamTrajectory *> trajs;
+  G4cout << "Starting. We have a neutrino of ID = " << track->GetTrackID()
+	 << " and whose parent is " << track->GetParentID() << G4endl;
   G4int trackIDTmp = track->GetParentID();
   while (trackIDTmp > 0) {
     G4cout << "We are looking at trackIDTmp = " << trackIDTmp << G4endl;
@@ -363,10 +365,15 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
     NuBeamTrajectory *tmpTraj = GetTrajectory(trackIDTmp);    
     int par_id = tmpTraj->GetParentID();
     if(tinst.ContainsTrajectory(trackIDTmp)) {
-      NuBeamTrajectory tr = tinst.GetTrajectory(trackIDTmp);
+      NuBeamTrajectory & tr = tinst.GetTrajectory(trackIDTmp);
       tmpTraj = &tr;
     }
-    trajs.push_back(tmpTraj);
+    // double check: are we adding trajectory points sensibly?
+    if((tmpTraj->GetTrajectoryPoints()).size() == 0) {
+      G4cout << "\tSKIPPING trajectory with ID = " << trackIDTmp << "!!!!" << G4endl;
+    } else {
+      trajs.push_back(tmpTraj);
+    }
     trackIDTmp = par_id; //tmpTraj->GetParentID();
   }
   std::reverse(trajs.begin(), trajs.end());

--- a/src/NuBeamOutput.cc
+++ b/src/NuBeamOutput.cc
@@ -354,19 +354,22 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
   fDk2Nu->decay.necm = enuzrInGeV; // Now in GeV... 
   //fDk2Nu->decay.nimpwt = track->GetWeight();
 
-  /*
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
   std::vector<NuBeamTrajectory *> trajs;
   G4int trackIDTmp = track->GetParentID();
   while (trackIDTmp > 0) {
+    G4cout << "We are looking at trackIDTmp = " << trackIDTmp << G4endl;
+    // if we tracked this process, just look it up from our map
     NuBeamTrajectory *tmpTraj = GetTrajectory(trackIDTmp);    
+    int par_id = tmpTraj->GetParentID();
+    if(tinst.ContainsTrajectory(trackIDTmp)) {
+      NuBeamTrajectory tr = tinst.GetTrajectory(trackIDTmp);
+      tmpTraj = &tr;
+    }
     trajs.push_back(tmpTraj);
-    trackIDTmp = tmpTraj->GetParentID();
-    if(trackIDTmp > 0) tmpTraj = GetTrajectory(trackIDTmp);  
+    trackIDTmp = par_id; //tmpTraj->GetParentID();
   }
   std::reverse(trajs.begin(), trajs.end());
-  */
-  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
-  std::vector<NuBeamTrajectory *> trajs;
 
   //add neutrino track info to ancestor since it is not in trajectory container yet
   G4String creatorProc=track->GetCreatorProcess()->GetProcessName()+":"+
@@ -375,14 +378,6 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
   nutraj->AddTrajectoryPoint(track,creatorProc);
   nutraj->AddTrajectoryPoint(track,creatorProc);
   trajs.push_back(nutraj);
-
-  // We'll make our way back along the trajectory map
-  while( trajs.back()->GetParentID() > 0 ) {
-    int par_id = trajs.back()->GetParentID();
-    G4cout << "Adding trajectory with ID = " << par_id << "..." << G4endl;
-    NuBeamTrajectory par_traj = tinst.GetTrajectory(par_id);
-    trajs.push_back(&par_traj);
-  }
   
 
   fDk2Nu->ancestor.clear();

--- a/src/NuBeamOutput.cc
+++ b/src/NuBeamOutput.cc
@@ -353,7 +353,8 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
   }  
   fDk2Nu->decay.necm = enuzrInGeV; // Now in GeV... 
   //fDk2Nu->decay.nimpwt = track->GetWeight();
-  
+
+  /*
   std::vector<NuBeamTrajectory *> trajs;
   G4int trackIDTmp = track->GetParentID();
   while (trackIDTmp > 0) {
@@ -363,6 +364,9 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
     if(trackIDTmp > 0) tmpTraj = GetTrajectory(trackIDTmp);  
   }
   std::reverse(trajs.begin(), trajs.end());
+  */
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  std::vector<NuBeamTrajectory *> trajs;
 
   //add neutrino track info to ancestor since it is not in trajectory container yet
   G4String creatorProc=track->GetCreatorProcess()->GetProcessName()+":"+
@@ -371,6 +375,15 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
   nutraj->AddTrajectoryPoint(track,creatorProc);
   nutraj->AddTrajectoryPoint(track,creatorProc);
   trajs.push_back(nutraj);
+
+  // We'll make our way back along the trajectory map
+  while( trajs.back()->GetParentID() > 0 ) {
+    int par_id = trajs.back()->GetParentID();
+    G4cout << "Adding trajectory with ID = " << par_id << "..." << G4endl;
+    NuBeamTrajectory par_traj = tinst.GetTrajectory(par_id);
+    trajs.push_back(&par_traj);
+  }
+  
 
   fDk2Nu->ancestor.clear();
   fDk2Nu->vint.clear();

--- a/src/NuBeamOutput.cc
+++ b/src/NuBeamOutput.cc
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <iostream>
+#include <algorithm>
 
 #include "NuBeamOutput.hh"
 #include "NuBeamOutputMessenger.hh"
@@ -49,6 +50,8 @@
 #include "TLorentzVector.h"
 #include "TRandom3.h"
 #include "TH1D.h"
+
+using namespace trajectory; // for access to trajPoint_t members
 
 NuBeamOutput::NuBeamOutput() :
   fMessenger(0)
@@ -356,10 +359,18 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
 
   NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
   std::vector<NuBeamTrajectory *> trajs;
+  // Ask the TrackingAction which steps it would like to save for tracking.
+  // Then load up only those steps into the output
+  std::vector< std::pair<G4int, std::vector<G4int>> > saved_steps; 
   G4int trackIDTmp = track->GetParentID();
   while (trackIDTmp > 0) {
     // if we tracked this process, just look it up from our map
     NuBeamTrajectory *tmpTraj = GetTrajectory(trackIDTmp);    
+    std::vector<G4int> track_saved_steps;
+    for( trajPoint_t st: tmpTraj->GetTrajectoryPoints() ) {
+      track_saved_steps.emplace_back(st.fStepNumber+1);
+    };
+    saved_steps.emplace_back( std::pair<G4int, std::vector<G4int>>( trackIDTmp, track_saved_steps ) );
     int par_id = tmpTraj->GetParentID();
     if(tinst.ContainsTrajectory(trackIDTmp)) {
       NuBeamTrajectory & tr = tinst.GetTrajectory(trackIDTmp);
@@ -383,6 +394,8 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
   nutraj->AddTrajectoryPoint(track,creatorProc);
   trajs.push_back(nutraj);
   
+  std::vector<G4int> nusteps = {0, 1}; // we added both neutrino steps
+  saved_steps.emplace_back( std::pair<G4int, std::vector<G4int>>( track->GetTrackID(), nusteps ) );
 
   fDk2Nu->ancestor.clear();
   fDk2Nu->vint.clear();
@@ -390,12 +403,23 @@ void NuBeamOutput::RecordNeutrino(const G4Track* track)
   // Now fill ancestry info. 
   // Set a global to track the previous weight.. if not 1, the weight should be that (1 pBe interaction that sets weight)
   G4double impwt = 1.0;
-  for (auto t: trajs) {
+  for (auto t: trajs) { 
     fDk2Nu->vint.push_back(t->GetTrackID());
-    std::vector<NuBeamTrajectory::trajPoint_t> trajPoints=t->GetTrajectoryPoints();
+    std::vector<trajPoint_t> trajPoints=t->GetTrajectoryPoints();
     //hadron elastic scatterings are added as additional points in trajectory
-    for (size_t iTP=0; iTP<trajPoints.size();iTP+=2) {
+    //for (size_t iTP=0; iTP<trajPoints.size();iTP+=2) {
+    std::vector< std::pair<G4int, std::vector<G4int>> >::iterator it_svs = saved_steps.begin();
+    while( it_svs != saved_steps.end() ) {
+      if( (*it_svs).first == t->GetTrackID() ) break;
+      ++it_svs;
+    }
+    std::vector<G4int> steps = (*it_svs).second;
+    for( size_t iTP = 0; iTP < trajPoints.size()-1; iTP+=2 ) {
+      // did we want to set this step?
+      if( std::find(steps.begin(), steps.end(),
+		    trajPoints[iTP].fStepNumber) == steps.end() ) continue;
       bsim::Ancestor a;
+      // also load the next step, for stopping momentum
       a.pdg     = t->GetPDGEncoding();
       a.startx  = trajPoints[iTP].fPosition[0]/CLHEP::cm;
       a.starty  = trajPoints[iTP].fPosition[1]/CLHEP::cm;

--- a/src/NuBeamSteppingAction.cc
+++ b/src/NuBeamSteppingAction.cc
@@ -53,6 +53,40 @@ void NuBeamSteppingAction::UserSteppingAction(const G4Step* s)
       particleType==G4Geantino::GeantinoDefinition());
 
   if (!interestingTrack) theTrack->SetTrackStatus(fStopAndKill);
+
+  // Add this trajectory to the container
+  NuBeamTrajectoryContainer & tinst = NuBeamTrajectoryContainer::Instance();
+  if( tinst.ContainsTrajectory(theTrack->GetTrackID()) ) {
+    // Reference means updates are always in place
+    NuBeamTrajectory & traj = tinst.GetTrajectory(theTrack->GetTrackID());
+    // Update info from the track now..
+    traj.SetFinalEnergy(theTrack->GetTotalEnergy());
+    traj.SetFinalMomentum(theTrack->GetMomentum());
+    traj.SetFinalPosition(theTrack->GetPosition());
+    traj.SetFinalPolarization(theTrack->GetPolarization());
+    traj.SetFinalTime(theTrack->GetGlobalTime());
+    traj.SetFinalStepNumber(theTrack->GetCurrentStepNumber());
+    G4String creatorProc = (theTrack->GetCreatorProcess() != 0) ?
+      theTrack->GetCreatorProcess()->GetProcessName() : "Primary";
+    traj.AddTrajectoryPoint( theTrack, creatorProc );
+    traj.AppendStep(s);
+    //tinst.AddTrajectory( traj ); // update in place
+  } else { // need to add this into the container
+    NuBeamTrajectory rtraj(theTrack);
+    std::unique_ptr<NuBeamTrajectory> traj = std::make_unique<NuBeamTrajectory>(rtraj);
+    // Technically, this is incorrect. It adds the post-1st step as the "initial" info.
+    traj->SetInitialEnergy(theTrack->GetTotalEnergy());
+    traj->SetInitialMomentum(theTrack->GetMomentum());
+    traj->SetInitialPosition(theTrack->GetPosition());
+    traj->SetInitialPolarization(theTrack->GetPolarization());
+    traj->SetInitialTime(theTrack->GetGlobalTime());
+    traj->SetInitialStepNumber(theTrack->GetCurrentStepNumber());
+    G4String creatorProc = (theTrack->GetCreatorProcess() != 0) ?
+      theTrack->GetCreatorProcess()->GetProcessName() : "Primary";
+    traj->AddTrajectoryPoint( theTrack, creatorProc );
+    traj->AppendStep(s);
+    tinst.AddTrajectory( std::move(traj) );
+  }
   
   if(fPerfectFocusingForPositives || fPerfectFocusingForNegatives) {
     if ( s->GetPreStepPoint()->GetPhysicalVolume()->GetName() == "HDSK"

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -46,7 +46,6 @@ NuBeamTrajectory::NuBeamTrajectory()
   fFinalStepNumber = 0;
 
   fTrajectoryPoints.clear();
-  fPositionRecord = std::vector<std::shared_ptr<G4TrajectoryPoint>>{};
 }
 
 NuBeamTrajectory::NuBeamTrajectory(const G4Track* aTrack)
@@ -54,8 +53,7 @@ NuBeamTrajectory::NuBeamTrajectory(const G4Track* aTrack)
   // static quantities
   //fPositionRecord = new NuBeamTrajectoryPointContainer();
   fPositionRecord.clear();
-  fPositionRecord.push_back( std::shared_ptr<
-			     G4TrajectoryPoint>(new G4TrajectoryPoint( aTrack->GetPosition() )) );
+  fPositionRecord.push_back(new G4TrajectoryPoint(aTrack->GetPosition()));
   fpParticleDefinition = aTrack->GetDefinition();
   fTrackID = aTrack->GetTrackID();
   fParentID = aTrack->GetParentID();
@@ -70,10 +68,12 @@ NuBeamTrajectory::NuBeamTrajectory(NuBeamTrajectory & right)
   : G4VTrajectory(right)
 {
   // static quantities
-  // Avoiding C-style casts which create dangling pointers
-  fPositionRecord.reserve(right.fPositionRecord.size());
-  for( const auto & rightPoint : right.fPositionRecord ) {
-    fPositionRecord.push_back( std::make_shared<G4TrajectoryPoint>( *rightPoint ) );
+  //fPositionRecord = new NuBeamTrajectoryPointContainer();
+  fPositionRecord.clear();
+  for(size_t i=0;i<right.fPositionRecord.size();i++) {
+    G4TrajectoryPoint* rightPoint =
+      (G4TrajectoryPoint*)((right.fPositionRecord)[i]);
+    fPositionRecord.push_back(new G4TrajectoryPoint(*rightPoint));
   }
   fpParticleDefinition = right.fpParticleDefinition;
   fTrackID = right.fTrackID;
@@ -87,17 +87,17 @@ NuBeamTrajectory::NuBeamTrajectory(NuBeamTrajectory & right)
 
 NuBeamTrajectory::~NuBeamTrajectory()
 {
-  // Destructor handles the semantics of free()
-  fPositionRecord.clear();
-  /*
   if (fPositionRecord.size() == 0) {
     return;
   }
+  /*
   size_t i;
   for(i=0;i<fPositionRecord.size();i++) {
     delete  fPositionRecord[i];
   }
   */
+  // Destructor handles the semantics of free()
+  fPositionRecord.clear();
 }
 
 void NuBeamTrajectory::AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc) 
@@ -128,14 +128,10 @@ void NuBeamTrajectory::ShowTrajectory(std::ostream& os) const
      << " points." << G4endl;
   
   for( size_t i=0 ; i < fPositionRecord.size() ; i++) {
-    /*
     G4TrajectoryPoint* aTrajectoryPoint =
-    (G4TrajectoryPoint*)(fPositionRecord[i]);
+      (G4TrajectoryPoint*)(fPositionRecord[i]);
     os << "Point[" << i << "]" 
        << " Position= " << aTrajectoryPoint->GetPosition() << G4endl;
-    */
-    os << "Point[" << i << "]" 
-       << " Position= " << (fPositionRecord[i])->GetPosition() << G4endl;
   }
 }
 /*
@@ -205,9 +201,8 @@ void NuBeamTrajectory::DrawTrajectory() const
 void NuBeamTrajectory::AppendStep(const G4Step* aStep)
 {
   fPositionRecord.
-    push_back(std::shared_ptr<
-	      G4TrajectoryPoint>( new
-				   G4TrajectoryPoint(aStep->GetPostStepPoint()->GetPosition()) ));
+    push_back(new
+	      G4TrajectoryPoint(aStep->GetPostStepPoint()->GetPosition() ));
 }
 
 G4ParticleDefinition* NuBeamTrajectory::GetParticleDefinition()
@@ -223,15 +218,10 @@ void NuBeamTrajectory::MergeTrajectory(G4VTrajectory* secondTrajectory)
   G4int ent = seco->GetPointEntries();
   for(G4int i=1;i<ent;i++) {
     // initial point of the second trajectory should not be merged 
-    /*
-    fPositionRecord.push_back( std::make_shared<
-			       G4TrajectoryPoint>((seco->fPositionRecord)[i]) );
+    fPositionRecord.push_back((seco->fPositionRecord)[i]);
     //    positionRecord->push_back(seco->positionRecord->removeAt(1));
-    */
-    if(seco->fPositionRecord[i])
-      fPositionRecord.push_back(std::make_shared<G4TrajectoryPoint>(*seco->fPositionRecord[i]));
   }
-  //delete (seco->fPositionRecord)[0]; //not needed now
+  delete (seco->fPositionRecord)[0];
   seco->fPositionRecord.clear();
 }
   

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -90,12 +90,13 @@ NuBeamTrajectory::~NuBeamTrajectory()
   if (fPositionRecord.size() == 0) {
     return;
   }
-  size_t i;
   /*
+  size_t i;
   for(i=0;i<fPositionRecord.size();i++) {
     delete  fPositionRecord[i];
   }
   */
+  // Destructor handles the semantics of free()
   fPositionRecord.clear();
 }
 

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -17,6 +17,8 @@
 
 #include "NuBeamTrackingAction.hh"
 
+using namespace trajectory;
+
 G4Allocator<NuBeamTrajectory> aTrajectoryAlloc;
 
 NuBeamTrajectory::NuBeamTrajectory()

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -21,7 +21,7 @@ G4Allocator<NuBeamTrajectory> aTrajectoryAlloc;
 
 NuBeamTrajectory::NuBeamTrajectory()
 {
-  fPositionRecord = 0;
+  //fPositionRecord = 0;
   fpParticleDefinition = 0;
   fTrackID = 0;
   fParentID = 0;
@@ -51,8 +51,9 @@ NuBeamTrajectory::NuBeamTrajectory()
 NuBeamTrajectory::NuBeamTrajectory(const G4Track* aTrack)
 {
   // static quantities
-  fPositionRecord = new NuBeamTrajectoryPointContainer();
-  fPositionRecord->push_back(new G4TrajectoryPoint(aTrack->GetPosition()));
+  //fPositionRecord = new NuBeamTrajectoryPointContainer();
+  fPositionRecord.clear();
+  fPositionRecord.push_back(new G4TrajectoryPoint(aTrack->GetPosition()));
   fpParticleDefinition = aTrack->GetDefinition();
   fTrackID = aTrack->GetTrackID();
   fParentID = aTrack->GetParentID();
@@ -67,11 +68,12 @@ NuBeamTrajectory::NuBeamTrajectory(NuBeamTrajectory & right)
   : G4VTrajectory(right)
 {
   // static quantities
-  fPositionRecord = new NuBeamTrajectoryPointContainer();
-  for(size_t i=0;i<right.fPositionRecord->size();i++) {
+  //fPositionRecord = new NuBeamTrajectoryPointContainer();
+  fPositionRecord.clear();
+  for(size_t i=0;i<right.fPositionRecord.size();i++) {
     G4TrajectoryPoint* rightPoint =
-      (G4TrajectoryPoint*)((*(right.fPositionRecord))[i]);
-    fPositionRecord->push_back(new G4TrajectoryPoint(*rightPoint));
+      (G4TrajectoryPoint*)((right.fPositionRecord)[i]);
+    fPositionRecord.push_back(new G4TrajectoryPoint(*rightPoint));
   }
   fpParticleDefinition = right.fpParticleDefinition;
   fTrackID = right.fTrackID;
@@ -85,16 +87,16 @@ NuBeamTrajectory::NuBeamTrajectory(NuBeamTrajectory & right)
 
 NuBeamTrajectory::~NuBeamTrajectory()
 {
-  if (fPositionRecord == 0) {
+  if (fPositionRecord.size() == 0) {
     return;
   }
   size_t i;
-  for(i=0;i<fPositionRecord->size();i++) {
-    delete  (*fPositionRecord)[i];
+  /*
+  for(i=0;i<fPositionRecord.size();i++) {
+    delete  fPositionRecord[i];
   }
-  fPositionRecord->clear();
-  
-  delete fPositionRecord;
+  */
+  fPositionRecord.clear();
 }
 
 void NuBeamTrajectory::AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc) 
@@ -121,12 +123,12 @@ void NuBeamTrajectory::ShowTrajectory(std::ostream& os) const
      << ":ParentID=" << fParentID << G4endl;
   os << "Particle name : " << fParticleName 
      << "  Charge : " << fPDGCharge << G4endl;
-  os << "  Current trajectory has " << fPositionRecord->size() 
+  os << "  Current trajectory has " << fPositionRecord.size() 
      << " points." << G4endl;
   
-  for( size_t i=0 ; i < fPositionRecord->size() ; i++) {
+  for( size_t i=0 ; i < fPositionRecord.size() ; i++) {
     G4TrajectoryPoint* aTrajectoryPoint =
-      (G4TrajectoryPoint*)((*fPositionRecord)[i]);
+      (G4TrajectoryPoint*)(fPositionRecord[i]);
     os << "Point[" << i << "]" 
        << " Position= " << aTrajectoryPoint->GetPosition() << G4endl;
   }
@@ -197,7 +199,7 @@ void NuBeamTrajectory::DrawTrajectory() const
 */
 void NuBeamTrajectory::AppendStep(const G4Step* aStep)
 {
-  fPositionRecord->
+  fPositionRecord.
     push_back(new
 	      G4TrajectoryPoint(aStep->GetPostStepPoint()->GetPosition() ));
 }
@@ -215,11 +217,11 @@ void NuBeamTrajectory::MergeTrajectory(G4VTrajectory* secondTrajectory)
   G4int ent = seco->GetPointEntries();
   for(G4int i=1;i<ent;i++) {
     // initial point of the second trajectory should not be merged 
-    fPositionRecord->push_back((*(seco->fPositionRecord))[i]);
+    fPositionRecord.push_back((seco->fPositionRecord)[i]);
     //    positionRecord->push_back(seco->positionRecord->removeAt(1));
   }
-  delete (*seco->fPositionRecord)[0];
-  seco->fPositionRecord->clear();
+  delete (seco->fPositionRecord)[0];
+  seco->fPositionRecord.clear();
 }
   
 NuBeamTrajectory* NuBeamTrajectory::GetParentTrajectory()

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -46,6 +46,7 @@ NuBeamTrajectory::NuBeamTrajectory()
   fFinalStepNumber = 0;
 
   fTrajectoryPoints.clear();
+  fPositionRecord = std::vector<std::shared_ptr<G4TrajectoryPoint>>{};
 }
 
 NuBeamTrajectory::NuBeamTrajectory(const G4Track* aTrack)
@@ -53,7 +54,8 @@ NuBeamTrajectory::NuBeamTrajectory(const G4Track* aTrack)
   // static quantities
   //fPositionRecord = new NuBeamTrajectoryPointContainer();
   fPositionRecord.clear();
-  fPositionRecord.push_back(new G4TrajectoryPoint(aTrack->GetPosition()));
+  fPositionRecord.push_back( std::shared_ptr<
+			     G4TrajectoryPoint>(new G4TrajectoryPoint( aTrack->GetPosition() )) );
   fpParticleDefinition = aTrack->GetDefinition();
   fTrackID = aTrack->GetTrackID();
   fParentID = aTrack->GetParentID();
@@ -68,12 +70,10 @@ NuBeamTrajectory::NuBeamTrajectory(NuBeamTrajectory & right)
   : G4VTrajectory(right)
 {
   // static quantities
-  //fPositionRecord = new NuBeamTrajectoryPointContainer();
-  fPositionRecord.clear();
-  for(size_t i=0;i<right.fPositionRecord.size();i++) {
-    G4TrajectoryPoint* rightPoint =
-      (G4TrajectoryPoint*)((right.fPositionRecord)[i]);
-    fPositionRecord.push_back(new G4TrajectoryPoint(*rightPoint));
+  // Avoiding C-style casts which create dangling pointers
+  fPositionRecord.reserve(right.fPositionRecord.size());
+  for( const auto & rightPoint : right.fPositionRecord ) {
+    fPositionRecord.push_back( std::make_shared<G4TrajectoryPoint>( *rightPoint ) );
   }
   fpParticleDefinition = right.fpParticleDefinition;
   fTrackID = right.fTrackID;
@@ -87,17 +87,17 @@ NuBeamTrajectory::NuBeamTrajectory(NuBeamTrajectory & right)
 
 NuBeamTrajectory::~NuBeamTrajectory()
 {
+  // Destructor handles the semantics of free()
+  fPositionRecord.clear();
+  /*
   if (fPositionRecord.size() == 0) {
     return;
   }
-  /*
   size_t i;
   for(i=0;i<fPositionRecord.size();i++) {
     delete  fPositionRecord[i];
   }
   */
-  // Destructor handles the semantics of free()
-  fPositionRecord.clear();
 }
 
 void NuBeamTrajectory::AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc) 
@@ -128,10 +128,14 @@ void NuBeamTrajectory::ShowTrajectory(std::ostream& os) const
      << " points." << G4endl;
   
   for( size_t i=0 ; i < fPositionRecord.size() ; i++) {
+    /*
     G4TrajectoryPoint* aTrajectoryPoint =
-      (G4TrajectoryPoint*)(fPositionRecord[i]);
+    (G4TrajectoryPoint*)(fPositionRecord[i]);
     os << "Point[" << i << "]" 
        << " Position= " << aTrajectoryPoint->GetPosition() << G4endl;
+    */
+    os << "Point[" << i << "]" 
+       << " Position= " << (fPositionRecord[i])->GetPosition() << G4endl;
   }
 }
 /*
@@ -201,8 +205,9 @@ void NuBeamTrajectory::DrawTrajectory() const
 void NuBeamTrajectory::AppendStep(const G4Step* aStep)
 {
   fPositionRecord.
-    push_back(new
-	      G4TrajectoryPoint(aStep->GetPostStepPoint()->GetPosition() ));
+    push_back(std::shared_ptr<
+	      G4TrajectoryPoint>( new
+				   G4TrajectoryPoint(aStep->GetPostStepPoint()->GetPosition()) ));
 }
 
 G4ParticleDefinition* NuBeamTrajectory::GetParticleDefinition()
@@ -218,10 +223,15 @@ void NuBeamTrajectory::MergeTrajectory(G4VTrajectory* secondTrajectory)
   G4int ent = seco->GetPointEntries();
   for(G4int i=1;i<ent;i++) {
     // initial point of the second trajectory should not be merged 
-    fPositionRecord.push_back((seco->fPositionRecord)[i]);
+    /*
+    fPositionRecord.push_back( std::make_shared<
+			       G4TrajectoryPoint>((seco->fPositionRecord)[i]) );
     //    positionRecord->push_back(seco->positionRecord->removeAt(1));
+    */
+    if(seco->fPositionRecord[i])
+      fPositionRecord.push_back(std::make_shared<G4TrajectoryPoint>(*seco->fPositionRecord[i]));
   }
-  delete (seco->fPositionRecord)[0];
+  //delete (seco->fPositionRecord)[0]; //not needed now
   seco->fPositionRecord.clear();
 }
   

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -96,6 +96,7 @@ NuBeamTrajectory::~NuBeamTrajectory()
   for(i=0;i<fPositionRecord.size();i++) {
     delete  fPositionRecord[i];
   }
+  fPositionRecord.clear();
 }
 
 void NuBeamTrajectory::AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc) 

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -97,6 +97,7 @@ NuBeamTrajectory::~NuBeamTrajectory()
     delete  fPositionRecord[i];
   }
   fPositionRecord.clear();
+  fTrajectoryPoints.clear();
 }
 
 void NuBeamTrajectory::AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc) 

--- a/src/NuBeamTrajectory.cc
+++ b/src/NuBeamTrajectory.cc
@@ -92,14 +92,10 @@ NuBeamTrajectory::~NuBeamTrajectory()
   if (fPositionRecord.size() == 0) {
     return;
   }
-  /*
   size_t i;
   for(i=0;i<fPositionRecord.size();i++) {
     delete  fPositionRecord[i];
   }
-  */
-  // Destructor handles the semantics of free()
-  fPositionRecord.clear();
 }
 
 void NuBeamTrajectory::AddTrajectoryPoint(const G4Track* aTrack, G4String creatorProc) 

--- a/src/NuBeamTrajectoryContainer.cc
+++ b/src/NuBeamTrajectoryContainer.cc
@@ -22,11 +22,14 @@ NuBeamTrajectory NuBeamTrajectoryContainer::GetTrajectory(int id) {
 
 void NuBeamTrajectoryContainer::AddTrajectory(NuBeamTrajectory traj) {
   int par_id = traj.GetParentID();
+  /*
   if( fTrajectories.find(par_id) != fTrajectories.end() ) {
     G4cout << "[NuBeamTrajectoryContainer]: " <<
       "WARNING: Trajectory with id = " << par_id << 
       " already in trajectory map!!! Not overriding" << G4endl;
     return;
   } else
-    fTrajectories[par_id] = traj;
+  */
+  NuBeamTrajectory ins = traj;
+  fTrajectories[par_id] = ins;
 }

--- a/src/NuBeamTrajectoryContainer.cc
+++ b/src/NuBeamTrajectoryContainer.cc
@@ -1,5 +1,6 @@
 #include "NuBeamTrajectoryContainer.hh"
 #include "G4ios.hh"
+#include <exception>
 
 NuBeamTrajectoryContainer & NuBeamTrajectoryContainer::Instance() { 
   static NuBeamTrajectoryContainer instance;
@@ -14,22 +15,13 @@ NuBeamTrajectory NuBeamTrajectoryContainer::GetTrajectory(int id) {
   if( fTrajectories.find(id) == fTrajectories.end() ) {
     G4cout << "[NuBeamTrajectoryContainer]: " <<
       "Trajectory with id = " << id << " not found in trajectory map!!" << G4endl;
-    NuBeamTrajectory traj = NuBeamTrajectory();
-    return traj;
+    throw std::runtime_error("Trajectory not handled");
   } else
     return fTrajectories[id]; // use of [id] means this can't be a const method
 }
 
 void NuBeamTrajectoryContainer::AddTrajectory(NuBeamTrajectory traj) {
   int par_id = traj.GetParentID();
-  /*
-  if( fTrajectories.find(par_id) != fTrajectories.end() ) {
-    G4cout << "[NuBeamTrajectoryContainer]: " <<
-      "WARNING: Trajectory with id = " << par_id << 
-      " already in trajectory map!!! Not overriding" << G4endl;
-    return;
-  } else
-  */
   NuBeamTrajectory ins = traj;
   fTrajectories[par_id] = ins;
 }

--- a/src/NuBeamTrajectoryContainer.cc
+++ b/src/NuBeamTrajectoryContainer.cc
@@ -11,17 +11,17 @@ NuBeamTrajectoryContainer::~NuBeamTrajectoryContainer() {
   fTrajectories.clear();
 }
 
-NuBeamTrajectory NuBeamTrajectoryContainer::GetTrajectory(int id) {
+NuBeamTrajectory & NuBeamTrajectoryContainer::GetTrajectory(int id) {
   if( fTrajectories.find(id) == fTrajectories.end() ) {
     G4cout << "[NuBeamTrajectoryContainer]: " <<
       "Trajectory with id = " << id << " not found in trajectory map!!" << G4endl;
     throw std::runtime_error("Trajectory not handled");
   } else
-    return fTrajectories[id]; // use of [id] means this can't be a const method
+    return *(fTrajectories[id]); // use of [id] means this can't be a const method
 }
 
-void NuBeamTrajectoryContainer::AddTrajectory(NuBeamTrajectory traj) {
-  int par_id = traj.GetParentID();
-  NuBeamTrajectory ins = traj;
-  fTrajectories[par_id] = ins;
+void NuBeamTrajectoryContainer::AddTrajectory(std::unique_ptr<NuBeamTrajectory> traj) {
+  int par_id = traj->GetTrackID();
+  //NuBeamTrajectory ins = traj;
+  fTrajectories[par_id] = std::move(traj);
 }

--- a/src/NuBeamTrajectoryContainer.cc
+++ b/src/NuBeamTrajectoryContainer.cc
@@ -1,0 +1,32 @@
+#include "NuBeamTrajectoryContainer.hh"
+#include "G4ios.hh"
+
+NuBeamTrajectoryContainer & NuBeamTrajectoryContainer::Instance() { 
+  static NuBeamTrajectoryContainer instance;
+  return instance;
+}
+
+NuBeamTrajectoryContainer::~NuBeamTrajectoryContainer() {
+  fTrajectories.clear();
+}
+
+NuBeamTrajectory NuBeamTrajectoryContainer::GetTrajectory(int id) {
+  if( fTrajectories.find(id) == fTrajectories.end() ) {
+    G4cout << "[NuBeamTrajectoryContainer]: " <<
+      "Trajectory with id = " << id << " not found in trajectory map!!" << G4endl;
+    NuBeamTrajectory traj = NuBeamTrajectory();
+    return traj;
+  } else
+    return fTrajectories[id]; // use of [id] means this can't be a const method
+}
+
+void NuBeamTrajectoryContainer::AddTrajectory(NuBeamTrajectory traj) {
+  int par_id = traj.GetParentID();
+  if( fTrajectories.find(par_id) != fTrajectories.end() ) {
+    G4cout << "[NuBeamTrajectoryContainer]: " <<
+      "WARNING: Trajectory with id = " << par_id << 
+      " already in trajectory map!!! Not overriding" << G4endl;
+    return;
+  } else
+    fTrajectories[par_id] = traj;
+}


### PR DESCRIPTION
Same as #8 , for the G4.10.6 product.
Repeating the body text here:

Another attempt to add back stopping momentum to the output tuples.

This refactors NuBeamOutput to grab the trajectory points from a singleton, NuBeamTrajectoryContainer, that is updated on each G4 step (and thus avoids the problem of G4 tracks setting momentum 0 once they've been stopped-and-killed).

Validations TBC.