### PR TITLE
Propagating QE interactions information to dk2nu

### DIFF
--- a/include/BooNEpBeInteraction.hh
+++ b/include/BooNEpBeInteraction.hh
@@ -51,8 +51,15 @@ private:
   static const G4int kNPtBins=100;
   static const G4int kNProtonMomentumBins=100;
 
+  // quasi-elastic interaction flag, store last interaction type
+  bool fLastInteractionWasQE;
+
 public:
   bool fIsQE;
+
+  // returns true if the last interaction was quasi-elastic
+  bool QuasiElasticStatus() {return fLastInteractionWasQE;}
+
   //we don't conserve momentum in this model at all, so set levels very high
   const std::pair< G4double, G4double > GetFatalEnergyCheckLevels() const {return std::pair<G4double, G4double>(100.*CLHEP::perCent, 1000. * CLHEP::GeV);};
 

--- a/include/NuBeamTrackInformation.hh
+++ b/include/NuBeamTrackInformation.hh
@@ -34,14 +34,45 @@ public:
   void SetCreatorModelName(G4String val) {fCreatorModelName=val;};
   G4String GetCreatorModelName() {return fCreatorModelName;};
 
+  // Set and get whether the creator process was a QE interaction (BooNE QE model)
+  void SetCreatorWasQE(G4bool val) {fCreatorWasQE=val;};
+  G4bool GetCreatorWasQE() const {return fCreatorWasQE;};
+
 private:
   G4String fCreatorModelName;
   G4int fDecayCodeDk2nu; // filled in BooNEStepping, at decay detection. 
   G4int fIsBiassed;
 
+  // Store whether the creator process was a QE interaction (BooNE QE model)
+  G4bool fCreatorWasQE;
+
+  // Store particle multiplicities from creator process
+  G4int fCreatorNProtons;
+  G4int fCreatorNNeutrons;
+  G4int fCreatorNPiPlus;
+  G4int fCreatorNPiMinus;
+  G4int fCreatorNKPlus;
+  G4int fCreatorNKMinus;
+  G4int fCreatorNOthers;
+
 public:
   inline G4int GetDecayCodeForDk2nu() const {return fDecayCodeDk2nu;}
   inline void  SetDecayCodeForDk2nu(G4int d)  {fDecayCodeDk2nu = d;}
+
+  inline G4int GetCreatorNProtons() const {return fCreatorNProtons;}
+  inline void  SetCreatorNProtons(G4int n)  {fCreatorNProtons = n;}
+  inline G4int GetCreatorNNeutrons() const {return fCreatorNNeutrons;}
+  inline void  SetCreatorNNeutrons(G4int n)  {fCreatorNNeutrons = n;}
+  inline G4int GetCreatorNPiPlus() const {return fCreatorNPiPlus;}
+  inline void  SetCreatorNPiPlus(G4int n)  {fCreatorNPiPlus = n;}
+  inline G4int GetCreatorNPiMinus() const {return fCreatorNPiMinus;}
+  inline void  SetCreatorNPiMinus(G4int n)  {fCreatorNPiMinus = n;}
+  inline G4int GetCreatorNKPlus() const {return fCreatorNKPlus;}
+  inline void  SetCreatorNKPlus(G4int n)  {fCreatorNKPlus = n;}
+  inline G4int GetCreatorNKMinus() const {return fCreatorNKMinus;}
+  inline void  SetCreatorNKMinus(G4int n)  {fCreatorNKMinus = n;}
+  inline G4int GetCreatorNOthers() const {return fCreatorNOthers;}
+  inline void  SetCreatorNOthers(G4int n)  {fCreatorNOthers = n;}
 };
 
 extern G4Allocator<NuBeamTrackInformation> aTrackInformationAllocator;

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -300,6 +300,23 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
       secTrack->SetUserInformation(tInfo);
     }
     tInfo->SetCreatorModelName(GetHadronicInteraction()->GetModelName()); 
+
+    // Propagate QE info for secondaries created in BooNEpBeInteraction to the track info
+    if (fInteraction->GetModelName() == "BooNEpBeInteraction") {
+      std::cout << "    --> HadronInelasticProcess QE:" 
+                << fBooNEpBeModel->QuasiElasticStatus() << " for track E " << secTrack->GetKineticEnergy() << " PDG: " << secTrack->GetParticleDefinition()->GetPDGEncoding() << std::endl;
+
+      tInfo->SetCreatorWasQE( fBooNEpBeModel->QuasiElasticStatus() );
+      // also update the main track info
+      NuBeamTrackInformation* mainInfo=dynamic_cast<NuBeamTrackInformation*>(aTrack.GetUserInformation());
+      if (mainInfo) {
+        mainInfo->SetCreatorWasQE( fBooNEpBeModel->QuasiElasticStatus() );
+      }
+
+    }
+    else {
+      tInfo->SetCreatorWasQE( false );
+    }
   }
 
   return theTotalResult;

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -303,15 +303,9 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
 
     // Propagate QE info for secondaries created in BooNEpBeInteraction to the track info
     if (fInteraction->GetModelName() == "BooNEpBeInteraction") {
-      std::cout << "    --> HadronInelasticProcess QE:" 
-                << fBooNEpBeModel->QuasiElasticStatus() << " for track E " << secTrack->GetKineticEnergy() << " PDG: " << secTrack->GetParticleDefinition()->GetPDGEncoding() << std::endl;
+      //std::cout << "    --> HadronInelasticProcess QE:" << fBooNEpBeModel->QuasiElasticStatus() << " for track E " << secTrack->GetKineticEnergy() << " PDG: " << secTrack->GetParticleDefinition()->GetPDGEncoding() << std::endl;
 
       tInfo->SetCreatorWasQE( fBooNEpBeModel->QuasiElasticStatus() );
-      // also update the main track info
-      NuBeamTrackInformation* mainInfo=dynamic_cast<NuBeamTrackInformation*>(aTrack.GetUserInformation());
-      if (mainInfo) {
-        mainInfo->SetCreatorWasQE( fBooNEpBeModel->QuasiElasticStatus() );
-      }
 
     }
     else {

--- a/src/BooNEHadronInelasticProcess.cc
+++ b/src/BooNEHadronInelasticProcess.cc
@@ -303,10 +303,7 @@ BooNEHadronInelasticProcess::PostStepDoIt(const G4Track& aTrack, const G4Step&)
 
     // Propagate QE info for secondaries created in BooNEpBeInteraction to the track info
     if (fInteraction->GetModelName() == "BooNEpBeInteraction") {
-      //std::cout << "    --> HadronInelasticProcess QE:" << fBooNEpBeModel->QuasiElasticStatus() << " for track E " << secTrack->GetKineticEnergy() << " PDG: " << secTrack->GetParticleDefinition()->GetPDGEncoding() << std::endl;
-
       tInfo->SetCreatorWasQE( fBooNEpBeModel->QuasiElasticStatus() );
-
     }
     else {
       tInfo->SetCreatorWasQE( false );

--- a/src/BooNEHadronQuasiElasticModel.cc
+++ b/src/BooNEHadronQuasiElasticModel.cc
@@ -103,10 +103,14 @@ BooNEHadronQuasiElasticModel::ApplyYourself(const  G4HadProjectile  &aHadron,
   // Define the secondaries necessary for the final state
   // first set final state of hadron, now back to MeV 
   // Kinetic energy
-  theParticleChange.SetEnergyChange( (hadronOutMomentum.e() - hadrMass) * CLHEP::GeV);
-
+  // theParticleChange.SetEnergyChange( (hadronOutMomentum.e() - hadrMass) * CLHEP::GeV);
   // Direction
-  theParticleChange.SetMomentumChange(hadronOutMomentum.vect().unit());
+  // theParticleChange.SetMomentumChange(hadronOutMomentum.vect().unit());
+  
+  // ^^^^^^^ Deprecated, create a new dynamic particle instead ^^^^^^^
+  G4DynamicParticle * outHadron = 
+    new G4DynamicParticle(theHadron->GetDefinition(), hadronOutMomentum.vect() * CLHEP::GeV);
+  theParticleChange.AddSecondary(outHadron);
   
   // decide if we scattered off at proton or a neutron
   // we'll use a simple scaling based on Z protons and (A-Z) neutrons;
@@ -138,6 +142,8 @@ BooNEHadronQuasiElasticModel::ApplyYourself(const  G4HadProjectile  &aHadron,
 
   }
 
+  // Stop and kill the incident particle, since it has been added as secondary
+  theParticleChange.SetStatusChange( stopAndKill );
 
   return &theParticleChange;
 

--- a/src/BooNEpBeInteraction.cc
+++ b/src/BooNEpBeInteraction.cc
@@ -1553,6 +1553,7 @@ BooNEpBeInteraction::ApplyYourself( const G4HadProjectile &aTrack,
   if (G4UniformRand()<qefrac) {
     fIsQE=true;
     G4HadFinalState* part=fQuasiElasticModel.ApplyYourself(aTrack,aNucl);
+    fLastInteractionWasQE = true;
     return part;
   }
   // if not QE, then generate the secondories from inelastic pBe
@@ -1562,6 +1563,8 @@ BooNEpBeInteraction::ApplyYourself( const G4HadProjectile &aTrack,
   // Note: no need to rotate secondaries' momentum in lab frame
   // using incident proton beam direction. This is now handled 
   // internally by G4
+
+  fLastInteractionWasQE = false;
 
   G4long nProton = 0;
   G4long nNeutron = 0;

--- a/src/NuBeamTrackInformation.cc
+++ b/src/NuBeamTrackInformation.cc
@@ -8,13 +8,29 @@ NuBeamTrackInformation::NuBeamTrackInformation()
   :
   fCreatorModelName(""),
   fDecayCodeDk2nu(0),
-  fIsBiassed(false)
+  fIsBiassed(false),
+  fCreatorWasQE(false),
+  fCreatorNProtons(0),
+  fCreatorNNeutrons(0),
+  fCreatorNPiPlus(0),
+  fCreatorNPiMinus(0),
+  fCreatorNKPlus(0),
+  fCreatorNKMinus(0),
+  fCreatorNOthers(0)
 {   
 }
 
 NuBeamTrackInformation::NuBeamTrackInformation(const G4Track*)
   :
-  fIsBiassed(false)
+  fIsBiassed(false),
+  fCreatorWasQE(false),
+  fCreatorNProtons(0),
+  fCreatorNNeutrons(0),
+  fCreatorNPiPlus(0),
+  fCreatorNPiMinus(0),
+  fCreatorNKPlus(0),
+  fCreatorNKMinus(0),
+  fCreatorNOthers(0)
 {
 }
 
@@ -23,6 +39,14 @@ NuBeamTrackInformation::NuBeamTrackInformation(const NuBeamTrackInformation* aTr
   fCreatorModelName = aTrackInfo->fCreatorModelName;
   fDecayCodeDk2nu = aTrackInfo->fDecayCodeDk2nu;
   fIsBiassed = aTrackInfo->fIsBiassed;
+  fCreatorWasQE = aTrackInfo->fCreatorWasQE;
+  fCreatorNProtons = aTrackInfo->fCreatorNProtons;
+  fCreatorNNeutrons = aTrackInfo->fCreatorNNeutrons;
+  fCreatorNPiPlus = aTrackInfo->fCreatorNPiPlus;
+  fCreatorNPiMinus = aTrackInfo->fCreatorNPiMinus;
+  fCreatorNKPlus = aTrackInfo->fCreatorNKPlus;
+  fCreatorNKMinus = aTrackInfo->fCreatorNKMinus;
+  fCreatorNOthers = aTrackInfo->fCreatorNOthers;
 }
 
 NuBeamTrackInformation::~NuBeamTrackInformation()

--- a/src/NuBeamTrackingAction.cc
+++ b/src/NuBeamTrackingAction.cc
@@ -75,9 +75,45 @@ void NuBeamTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
       // dynamic initial trajectory information
       if (aTrack->GetTrackID()==1) 
 	creatorProc="Primary";
-      else
+      else{
 	creatorProc=aTrack->GetCreatorProcess()->GetProcessName()+":"+
 	  ((NuBeamTrackInformation*)aTrack->GetUserInformation())->GetCreatorModelName();
+
+        // Add additional suffix for BooNEHadronInelastic processes
+        // For QE BooNE interactions, add :QEBooNE
+        // For production (either BooNEpBeInteraction or default G4 hadronic models),
+        // add :<multiplicities> (e.g. 2P1N3PiM0PiP0KP0KM0Oth)
+        if ( creatorProc.find("BooNEHadronInelastic")!=G4String::npos ){
+
+          // string with particle multiplicites
+          G4String multStr = "";
+          NuBeamTrackInformation* tInfo = (NuBeamTrackInformation*)aTrack->GetUserInformation();
+          if(tInfo){
+            multStr += std::to_string( tInfo->GetCreatorNProtons() ) + "P";
+            multStr += std::to_string( tInfo->GetCreatorNNeutrons() ) + "N";
+            multStr += std::to_string( tInfo->GetCreatorNPiPlus() ) + "PiM";
+            multStr += std::to_string( tInfo->GetCreatorNPiMinus() ) + "PiP";
+            multStr += std::to_string( tInfo->GetCreatorNKPlus() ) + "KP";
+            multStr += std::to_string( tInfo->GetCreatorNKMinus() ) + "KM";
+            multStr += std::to_string( tInfo->GetCreatorNOthers() ) + "Oth";
+          }
+
+          // if BooNEpBeInteraction
+          if( creatorProc.find("BooNEpBeInteraction")!=G4String::npos ) {
+            G4bool wasQE = ((NuBeamTrackInformation*)aTrack->GetUserInformation())->GetCreatorWasQE();
+            if (wasQE) {
+              creatorProc += ":QEBooNE";
+            }
+            else{
+              creatorProc += ":" + multStr;
+            }
+          }
+          else{
+            creatorProc += ":" + multStr;
+          }
+        }
+
+      }
 
       trajectory->SetCreatorProcessName(creatorProc);
       trajectory->SetInitialEnergy( aTrack->GetTotalEnergy() );
@@ -119,6 +155,68 @@ void NuBeamTrackingAction::PostUserTrackingAction(const G4Track* aTrack)
     trajectory->SetFinalStepNumber( aTrack->GetCurrentStepNumber() );
     trajectory->AddTrajectoryPoint(aTrack, "Final");
   }
+
+  // Get the secondaries produced in this track's processes
+  G4TrackVector* secondaries = fpTrackingManager->GimmeSecondaries();
+  size_t nSeco = secondaries->size();
+  
+  // Check if the interaction was inelastic hadronic
+  // and add multiplicities to the track information
+  bool is_ine = false;   
+  for(size_t i=0;i<nSeco;i++){
+    G4Track* secondary=(*secondaries)[i];
+    int tpdg = secondary->GetParticleDefinition()->GetPDGEncoding();
+    if( abs(tpdg)<100 )continue;
+    G4String tproc = secondary->GetCreatorProcess()->GetProcessName();
+    if(tproc == "BooNEHadronInelastic"){is_ine = true;}
+  }
+  
+  // If inelastic, check secondary particles in the final state
+  if( is_ine ){
+
+    // Do the counting of final state particles
+    int nProton = 0;
+    int nNeutron = 0;
+    int nPiMinus = 0;
+    int nPiPlus = 0;
+    int nKPlus = 0;
+    int nKMinus = 0;
+    int nOthers = 0;
+    for(size_t i=0; i < nSeco; i++){	
+      G4Track* secondary=(*secondaries)[i];
+      int tpropdg = secondary->GetParticleDefinition()->GetPDGEncoding();
+      if( abs(tpropdg)<100 || abs(tpropdg)>1000000 ) continue;
+      else if( tpropdg == 2212 ) nProton++;
+      else if( tpropdg == 2112 ) nNeutron++;
+      else if( tpropdg == 211 ) nPiPlus++;
+      else if( tpropdg == -211 ) nPiMinus++;
+      else if( tpropdg == 321 ) nKPlus++;
+      else if( tpropdg == -321 ) nKMinus++;
+      else nOthers++;
+    }
+
+    // Now set the multiplicities in the track information of all hadronic secondaries
+    for(size_t i=0; i < nSeco; i++){	
+      G4Track* secondary=(*secondaries)[i];
+
+      int tpropdg = secondary->GetParticleDefinition()->GetPDGEncoding();
+      if( abs(tpropdg)<100 || abs(tpropdg)>1000000 ) continue;
+
+      NuBeamTrackInformation* mainInfo=dynamic_cast<NuBeamTrackInformation*>(secondary->GetUserInformation());
+      if (mainInfo) {
+        mainInfo->SetCreatorNProtons(nProton);
+        mainInfo->SetCreatorNNeutrons(nNeutron);
+        mainInfo->SetCreatorNPiPlus(nPiPlus);
+        mainInfo->SetCreatorNPiMinus(nPiMinus);
+        mainInfo->SetCreatorNKPlus(nKPlus);
+        mainInfo->SetCreatorNKMinus(nKMinus);
+        mainInfo->SetCreatorNOthers(nOthers);
+      }
+    }
+
+  }
+
+
   
   return;
 

--- a/src/NuBeamTrackingAction.cc
+++ b/src/NuBeamTrackingAction.cc
@@ -87,7 +87,7 @@ void NuBeamTrackingAction::PreUserTrackingAction(const G4Track* aTrack)
 
           // string with particle multiplicites
           G4String multStr = "";
-          NuBeamTrackInformation* tInfo = (NuBeamTrackInformation*)aTrack->GetUserInformation();
+          NuBeamTrackInformation* tInfo = dynamic_cast<NuBeamTrackInformation*>(aTrack->GetUserInformation());
           if(tInfo){
             multStr += std::to_string( tInfo->GetCreatorNProtons() ) + "P";
             multStr += std::to_string( tInfo->GetCreatorNNeutrons() ) + "N";


### PR DESCRIPTION
This PRs introduces two modifications to better handle QE interactions within the uncertainty manager package.
More information is available in [docdb-44415](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=44415).
**Save QE interactions as additional ancestors**
Currently, QE interactions modeled by the BooNEQuasiElastic class does not kill the incident proton (leading). That means ancestors created in QE interactions are not propagated to dk2nu. This is no the case for Elastic and Inelastic:Production interactions.

**Adds an additional label to the process name to store if the interaction was QE**
Since QE interactions are handled within the BooNEpBeInteraction class (together with production processes), it is not possible to tell from the dk2nu whether the process was Inelastic:Production or Inelastic:QE. This PR adds an additional string to the process name to explicitly store this information. Some examples are shown below.

Example A: ancestor chain for an inelastic/production

```
3 ancestors
[ 0] pdg= 2212 "Primary" "PICV" nucleus 0
     startx  {-0.100725,0.0781415,-1;t=0}
     startpx {0.00391337,-0.00370449,8.88889}
     pprodpx {0,0,0}
     stoppx  {0,-0,0}
[ 1] pdg=  211 "BooNEHadronInelastic:BooNEpBeInteraction:2P1N6PiM8PiP1KP0KM0Oth" "TARG" nucleus 0
     startx  {-0.0985817,0.0761137,3.86486;t=0.163176}
     startpx {-0.143942,0.145833,6.58481}
     pprodpx {0,0,0}
     stoppx  {-0.0713641,0.061056,6.47463}
[ 2] pdg=   14 "Decay:" "DKDV" nucleus 0
     startx  {-37.9501,31.1183,3283.66;t=109.603}
     startpx {-0.0142842,-0.00579268,2.03447}
     pprodpx {0,0,0}
     stoppx  {-0.0142842,-0.00579268,2.03447}
```

Example B: ancestor chain for an inelastic/QE

```
5 ancestors
[ 0] pdg= 2212 "Primary" "PICV" nucleus 0
     startx  {0.0246596,0.0121905,-1;t=0}
     startpx {-0.000958076,-0.000577922,8.88889}
     pprodpx {0,0,0}
     stoppx  {-0,0,0}
[ 1] pdg= 2212 "BooNEHadronInelastic:BooNEpBeInteraction:QEBooNE" "TARG" nucleus 0
     startx  {0.0226657,0.0128719,10.5354;t=0.38692}
     startpx {-0.0490452,0.285403,8.81747}
     pprodpx {0,0,0}
     stoppx  {-0,0,0}
[ 2] pdg= 2212 "BooNEHadronInelastic:FTFP:2P2N0PiM0PiP0KP0KM0Oth" "HWL1" nucleus 0
     startx  {-0.344593,2.05369,72.858;t=2.47876}
     startpx {-0.356697,-0.282205,8.54457}
     pprodpx {0,0,0}
     stoppx  {-0,-0,0}
[ 3] pdg=  211 "BooNEHadronInelastic:FTFP:7P6N1PiM1PiP0KP0KM0Oth" "DKO1" nucleus 0
     startx  {-67.0008,-62.357,2060.35;t=69.2481}
     startpx {0.0475893,0.0654363,0.877149}
     pprodpx {0,0,0}
     stoppx  {0.0470514,0.067133,0.871821}
[ 4] pdg=   14 "Decay:" "HOL2" nucleus 0
     startx  {-17.7057,6.77375,2964.22;t=99.9123}
     startpx {0.012643,0.0171605,0.358673}
     pprodpx {0,0,0}
     stoppx  {0.012643,0.0171605,0.358673}
```