### PR TITLE
Add check for muon capture and swap dkp_mum_nusep <--> dkp_mup_nusep

### DIFF
--- a/src/NuBeamOutput.cc
+++ b/src/NuBeamOutput.cc
@@ -654,6 +654,9 @@ G4int NuBeamOutput::GetDecayCode(const G4Track* nuTrack)
 		       nuTrack->GetMomentum().z(),
 		       nuTrack->GetTotalEnergy());
 
+  G4ProcessType creator_ptype = (nuTrack->GetCreatorProcess())->GetProcessType();
+  G4String creator_name = (nuTrack->GetCreatorProcess())->GetProcessName();
+
   switch (parentTraj->GetPDGEncoding()) {
   case 130:
   case 311:
@@ -702,11 +705,15 @@ G4int NuBeamOutput::GetDecayCode(const G4Track* nuTrack)
       return bsim::dkp_unknown;
     }
     break;
-  case 13: 
-    return bsim::dkp_mup_nusep;
+  // For muons, check if the creator process was decay or capture
+  case 13:
+    if( creator_ptype == fDecay ) { return bsim::dkp_mum_nusep; }
+    else if( creator_name.find("Capture") != std::string::npos ) { return bsim::dk_mum_capture; }
+    else { return bsim::dkp_unknown; }
     break;
   case -13: 
-    return bsim::dkp_mum_nusep;
+    if( creator_ptype == fDecay ) { return bsim::dkp_mup_nusep; }
+    else { return bsim::dkp_unknown; }
     break;
   case 211:
     switch (nuTrack->GetParticleDefinition()->GetPDGEncoding()) {


### PR DESCRIPTION
The code for `bsim::calcLocationWeight` expects that neutrinos marked as `bsim::dkp_mu*_nusep` are produced from muon decays. It then applies a polarisation correction to those neutrinos, as seen [in the dk2nu code](https://github.com/NuSoftHEP/dk2nu/blob/main/tree/calcLocationWeights.cxx#L240C2-L322C6).

G4BNB had been assigning `bsim::dkp_mup_nusep` to neutrinos with a muon-minus parent, and `bsim::dkp_mum_nusep` to neutrinos with a muon-plus parent.

In processing of G4BNB with the muon threshold set to `0.`, @JosiePaton noticed millions of events of the type
```
bsim::calcEnuWgt encountered serious problem: wgt_ratio -2.72997 enu 0.0985139 costh 0.996916 xnu 1.86476 enuzr=decay.necm 0.0985139 kMUMASS 0.105658 norig 3 ndecay 11 ntype 14 ptype 13
```
Conversations with @JosiePaton and @marcodeltutto revealed that these were muon capture events incorrectly tagged as muon decays.
This PR assigns events correctly.

A low-statistics test of 10,000 POT was carried out, with this output:
```
N entries = 31477
N entries (ptype == 13): 2860 # mu- parent
N entries (ptype == 13 && ndecay == 12): 8 # mu- parent DAR
N entries (ptype == 13 && ndecay == 15): 2852 # mu- parent capture
N entries (ptype == -13): 16344 # mu+ parent
N entries (ptype == -13 && ndecay == 11): 16344 # mu+ parent DAR
```